### PR TITLE
Feat/bomb & player

### DIFF
--- a/client/src/game/dto/bomb.dto.ts
+++ b/client/src/game/dto/bomb.dto.ts
@@ -1,5 +1,6 @@
-import { GameObjectDto } from "./gameObject.dto";
+import { GameObjectDto } from './gameObject.dto';
 
 export interface BombDto extends GameObjectDto {
-    id: number;
-  }
+  id: number;
+  animation: string;
+}

--- a/client/src/game/scene/MainScene.ts
+++ b/client/src/game/scene/MainScene.ts
@@ -1,3 +1,4 @@
+import { BombDto } from '../dto/bomb.dto';
 import { NpcDto } from '../dto/npc.dto';
 import { ObstacleDto } from '../dto/obstacle.dto';
 import { PlayerDto } from '../dto/player.dto';
@@ -7,15 +8,6 @@ import { CustomScene } from './parent/customScene';
 
 export class MainScene extends CustomScene {
   cursor: Cursor | null = null;
-  
-  // public socket: any;
-
-  // objects: { [key: string]: { [id: string]: any } } = {
-  //   playerMap: {},
-  //   npcMap: {},
-  //   obstacleMap: {},
-  //   bombMap: {}
-  // };
 
   constructor() {
     super({ key: 'MainScene' });
@@ -39,39 +31,28 @@ export class MainScene extends CustomScene {
         playerArr: PlayerDto[];
         npcArr: NpcDto[];
         obstacleArr: ObstacleDto[];
-        // bombの配列を追加
-        bombArr: any[]
+        bombArr: BombDto[];
       }) => {
         SyncUtil.setPlayer(res.playerArr, this);
         SyncUtil.setNpc(res.npcArr, this);
         SyncUtil.setObstacle(res.obstacleArr, this);
-        // 1/18
-        // if (res.bombArr.length > 0) {
-        //   res.bombArr.map((obstacle) => {
-        //     if (!this.objects.bombMap[obstacle.id]) {
-        //       let sprite = this.add
-        //         .sprite(
-        //           obstacle.x,
-        //           obstacle.y,
-        //           obstacle.spriteKey
-        //         )
-        //         .setOrigin(0.5);
-        //       this.objects.bombMap[obstacle.id] = {
-        //         sprite: sprite,
-        //       };
-        //     }
-        //     this.objects.bombMap[obstacle.id]['sync'] =
-        //       obstacle;
-        //   });
-        // }
-
+        SyncUtil.setBomb(res.bombArr, this);
       }
     );
+
+    this.socket.on('destroyBomb', (res: { id: number }) => {
+      SyncUtil.destroyBomb(res.id, this);
+    });
+
+    this.socket.on('destroyPlayer', (res: { clientId: string }) => {
+      SyncUtil.destroyPlayer(res.clientId, this);
+    });
   }
   update(): void {
     //syncのデータを基に、spriteの座標とアニメーションを更新
     SyncUtil.updatePlayer(this);
     SyncUtil.updateNpc(this);
+    SyncUtil.updateBomb(this);
 
     this.cursor?.update();
   }

--- a/client/src/game/scene/PreloadScene.ts
+++ b/client/src/game/scene/PreloadScene.ts
@@ -9,49 +9,32 @@ export class PreloadScene extends Scene {
   preload() {
     //画像の読み込み
     this.load.image('blueBrick', '/assets/blue_brick.png');
-    this.load.image(
-      'orangeBrick',
-      '/assets/orange_brick.png'
-    );
+    this.load.image('orangeBrick', '/assets/orange_brick.png');
     this.load.image('grayBrick', '/assets/gray_brick.png');
-    this.load.image(
-      'greenBrick',
-      '/assets/green_brick.png'
-    );
+    this.load.image('greenBrick', '/assets/green_brick.png');
 
-    this.load.spritesheet(
-      'player',
-      '/assets/player_spritesheet_fixed.png',
-      {
-        frameWidth: 32,
-        frameHeight: 32,
-      }
-    );
-    this.load.spritesheet(
-      'npc',
-      '/assets/enemy_spritesheet_fixed.png',
-      {
-        frameWidth: 32,
-        frameHeight: 32,
-      }
-    );
+    this.load.spritesheet('player', '/assets/player_spritesheet_fixed.png', {
+      frameWidth: 32,
+      frameHeight: 32,
+    });
+    this.load.spritesheet('npc', '/assets/enemy_spritesheet_fixed.png', {
+      frameWidth: 32,
+      frameHeight: 32,
+    });
     this.load.spritesheet('bomb', '/assets/bomb.png', {
       frameWidth: 32,
       frameHeight: 32,
     });
-    this.load.spritesheet(
-      'explosion',
-      '/assets/explode.png',
-      {
-        frameWidth: 32,
-        frameHeight: 32,
-      }
-    );
+    this.load.spritesheet('explosion', '/assets/explode.png', {
+      frameWidth: 32,
+      frameHeight: 32,
+    });
   }
   create() {
     //アニメーションを作成
     AnimationUtil.createPlayerAnim(this);
     AnimationUtil.createNpcAnim(this);
+    AnimationUtil.createBombAnim(this);
   }
 
   update() {

--- a/client/src/game/util/animation.util.ts
+++ b/client/src/game/util/animation.util.ts
@@ -55,8 +55,7 @@ export class AnimationUtil {
     direction: number
   ) {
     if (!sprite.anims.isPlaying) sprite.play(animation);
-    else if (sprite.anims.getName() !== animation)
-      sprite.play(animation);
+    else if (sprite.anims.getName() !== animation) sprite.play(animation);
     //左に進むときは右方向の動きを反転させる
     sprite.setFlipX(direction === 3);
   }
@@ -67,10 +66,13 @@ export class AnimationUtil {
     direction: number
   ) {
     if (!sprite.anims.isPlaying) sprite.play(animation);
-    else if (sprite.anims.getName() !== animation)
-      sprite.play(animation);
+    else if (sprite.anims.getName() !== animation) sprite.play(animation);
     //左に進むときは右方向の動きを反転させる
     sprite.setFlipX(direction === 3);
+  }
+  static setBombAnimation(sprite: Phaser.GameObjects.Sprite, animation: string) {
+    if (!sprite.anims.isPlaying) sprite.play(animation);
+    else if (sprite.anims.getName() !== animation) sprite.play(animation);
   }
 
   static createNpcAnim(scene: Scene) {
@@ -121,7 +123,7 @@ export class AnimationUtil {
     });
   }
 
-  static createBumbAnim(scene: Scene) {
+  static createBombAnim(scene: Scene) {
     scene.anims.create({
       key: 'bomb-anim',
       frameRate: 10,
@@ -138,13 +140,10 @@ export class AnimationUtil {
       key: 'explosion-anim',
       frameRate: 20,
       repeat: 0,
-      frames: scene.anims.generateFrameNumbers(
-        'explosion',
-        {
-          start: 0,
-          end: 9,
-        }
-      ),
+      frames: scene.anims.generateFrameNumbers('explosion', {
+        start: 0,
+        end: 9,
+      }),
     });
   }
 }

--- a/client/src/game/util/sync.util.ts
+++ b/client/src/game/util/sync.util.ts
@@ -1,3 +1,4 @@
+import { BombDto } from '../dto/bomb.dto';
 import { NpcDto } from '../dto/npc.dto';
 import { ObstacleDto } from '../dto/obstacle.dto';
 import { PlayerDto } from '../dto/player.dto';
@@ -5,10 +6,7 @@ import { CustomScene } from '../scene/parent/customScene';
 import { AnimationUtil } from './animation.util';
 
 export class SyncUtil {
-  static setPlayer(
-    playerArr: PlayerDto[],
-    scene: CustomScene
-  ) {
+  static setPlayer(playerArr: PlayerDto[], scene: CustomScene) {
     if (playerArr && playerArr.length > 0) {
       playerArr.forEach((player) => {
         //clientIdに対応するデータがない場合、新たにspriteを作成する
@@ -23,8 +21,7 @@ export class SyncUtil {
           };
         }
         //updateメソッドで使用するためのデータをsyncに格納する
-        scene.objects.playerMap[player.clientId]['sync'] =
-          player;
+        scene.objects.playerMap[player.clientId]['sync'] = player;
       });
     }
   }
@@ -47,19 +44,12 @@ export class SyncUtil {
     }
   }
 
-  static setObstacle(
-    obstacleArr: ObstacleDto[],
-    scene: CustomScene
-  ) {
+  static setObstacle(obstacleArr: ObstacleDto[], scene: CustomScene) {
     if (obstacleArr && obstacleArr.length > 0) {
       obstacleArr.map((obstacle) => {
         if (!scene.objects.obstacleMap[obstacle.id]) {
           let sprite = scene.add
-            .sprite(
-              obstacle.x,
-              obstacle.y,
-              obstacle.spriteKey
-            )
+            .sprite(obstacle.x, obstacle.y, obstacle.spriteKey)
             .setOrigin(0.5)
             .setScale(1.25);
           scene.objects.obstacleMap[obstacle.id] = {
@@ -67,8 +57,53 @@ export class SyncUtil {
             sync: null,
           };
         }
-        scene.objects.obstacleMap[obstacle.id]['sync'] =
-          obstacle;
+        scene.objects.obstacleMap[obstacle.id]['sync'] = obstacle;
+      });
+    }
+  }
+
+  static setBomb(bombArr: BombDto[], scene: CustomScene) {
+    // console.log('爆弾の配列', bombArr);
+    if (bombArr && bombArr.length > 0) {
+      bombArr.map((bomb) => {
+        if (!scene.objects.bombMap[bomb.id]) {
+          let sprite = scene.add
+            .sprite(bomb.x, bomb.y, bomb.spriteKey)
+            .setOrigin(0.5)
+            .setScale(1.25);
+          scene.objects.bombMap[bomb.id] = {
+            sprite: sprite,
+            sync: null,
+          };
+        }
+        scene.objects.bombMap[bomb.id]['sync'] = bomb;
+      });
+    }
+  }
+
+  static destroyPlayer(clientId: string, scene: CustomScene) {
+    let player = scene.objects.playerMap[clientId];
+    if (!player) return;
+    player.sprite.destroy();
+    player.sync = null;
+
+    delete scene.objects.playerMap[clientId];
+  }
+
+  static destroyBomb(id: number, scene: CustomScene) {
+    let bomb = scene.objects.bombMap[id];
+    if (!bomb) return;
+    bomb.sprite.destroy();
+    bomb.sync = null;
+
+    delete scene.objects.bombMap[id];
+  }
+
+  static updateBomb(scene: CustomScene) {
+    if (Object.keys(scene.objects.bombMap).length > 0) {
+      Object.values(scene.objects.bombMap).forEach((bomb) => {
+        if (!bomb.sync) return;
+        AnimationUtil.setBombAnimation(bomb.sprite, bomb.sync.animation);
       });
     }
   }
@@ -76,21 +111,19 @@ export class SyncUtil {
   static updatePlayer(scene: CustomScene) {
     //syncのデータを基に、spriteの座標とアニメーションを更新
     if (Object.keys(scene.objects.playerMap).length > 0) {
-      Object.values(scene.objects.playerMap).forEach(
-        (player) => {
-          if (!player.sync) return;
-          //座標を更新
-          player.sprite.x = player.sync.x;
-          player.sprite.y = player.sync.y;
+      Object.values(scene.objects.playerMap).forEach((player) => {
+        if (!player.sync) return;
+        //座標を更新
+        player.sprite.x = player.sync.x;
+        player.sprite.y = player.sync.y;
 
-          //アニメーションを更新
-          AnimationUtil.setPlayerAnimation(
-            player.sprite,
-            player.sync.animation,
-            player.sync.direction
-          );
-        }
-      );
+        //アニメーションを更新
+        AnimationUtil.setPlayerAnimation(
+          player.sprite,
+          player.sync.animation,
+          player.sync.direction
+        );
+      });
     }
   }
 

--- a/server/src/game/game.ts
+++ b/server/src/game/game.ts
@@ -44,6 +44,7 @@ export class Game {
         time: deltaTime,
         playerArr: this.stage.playerList.toArray(),
         npcArr: this.stage.npcList.toArray(),
+        bombArr: this.stage.bombList.toArray(),
       });
     }, 1000 / ServerConfig.FRAMERATE); // 単位は[ms]。1000[ms] / FRAMERATE[回]
   }

--- a/server/src/game/model/bomb.ts
+++ b/server/src/game/model/bomb.ts
@@ -3,79 +3,41 @@ import { GameObject } from './gameObject/gameObject';
 import { Player } from './player/player';
 
 export class Bomb extends GameObject {
-  static WIDTH = 38.4;
-  static HEIGHT = 38.4;
-  private bombExisted: boolean;
+  static readonly WIDTH = 38.4;
+  static readonly HEIGHT = 38.4;
   private remainTime: number = 5;
-  private animation : string;
-  // private bombs: Phaser.GameObjects.Group;
-  // private bombLog: {
-  //   x: number;
-  //   y: number;
-  //   existed: boolean;
-  // };
-  // private obj = GameObject;
-  constructor(x: number, y: number, private player: Player, public id : number) {
-    // 親クラスのコンストラクタ呼び出し
+  private animation: string = 'bomb-anim';
+  constructor(public id: number, x: number, y: number, public player: Player) {
     super(x, y, Bomb.WIDTH, Bomb.HEIGHT, 'bomb');
-    // 1/20
-    this.bombExisted = false;
-    this.id = 0;
-    this.animation = "bomb-anim";
   }
 
   toJSON() {
     return Object.assign(super.toJSON(), {
+      id: this.id,
       animation: this.animation,
     });
   }
 
-  public get getRemainTime():number{
+  public get getRemainTime(): number {
     return this.remainTime;
   }
-  
-  public set setRemainTime(time:number){
-    this.remainTime -= time;
+
+  public set setRemainTime(time: number) {
+    this.remainTime = time;
   }
+
+  public reduceRemainTime(time: number) {
+    this.setRemainTime = this.getRemainTime - time;
+  }
+
   update(deltaTime: number) {
     this.remainTime -= deltaTime;
-    if (this.remainTime < 0) {
+    if (this.remainTime <= 0) {
       //爆発
       // new Explosion();
     }
-
-    // let bomb: any;
-    // if (this.player.putBomb()) {
-    //   if (
-    //     this.getPosition.x != this.player.getPosition.x ||
-    //     this.getPosition.y != this.player.getPosition.y ||
-    //     !this.bombExisted
-    //   ) {
-    //     // bomb Map呼び出し方がわからない
-    //     bomb = this.objects.bombMap.create(
-    //       this.player.getPosition.x,
-    //       this.player.getPosition.y,
-    //       'bomb'
-    //     );
-    //     this.bombExisted = true;
-    //     // this.player.decreaseBombCounter();
-    //     bomb.anims.play('bomb-anim', true);
-
-        // setTimeout(() => {
-        //   // bomb.xは何のこと？
-        //   this.setPosition(bomb.x, bomb.y);
-        //   // this.setPosition = bomb.y;
-        //   bomb.destroy();
-        //   this.bombExisted= false;
-        //   // this.player.increaseBombCounter();
-        //   setTimeout(() => {
-        //     this.explosion.clear(true, true);
-        //     this.player.setHit = false;
-        //   }, 600);
-        // }, 2000);
-
-        }
-    // }
+  }
+  // }
 
   // }
   // アニメーションを追加

--- a/server/src/game/model/character/character.ts
+++ b/server/src/game/model/character/character.ts
@@ -4,6 +4,8 @@ import { ObjectUtil } from '../../util/object.util';
 import { GameObject } from '../gameObject/gameObject';
 import { GenericObstacle } from '../obstacle/generic/genericObstacle';
 import { GenericLinkedList } from '../../../linkedList/generic/genericLinkedList';
+import { Bomb } from '../bomb';
+import { OverlapUtil } from '../../util/overlap.util';
 
 export class Character extends GameObject {
   static WIDTH = 38.4;
@@ -83,7 +85,8 @@ export class Character extends GameObject {
     this.animation = value;
   }
   damage() {
-    return this.life--;
+    console.log('ダメージを受けました');
+    this.life--;
   }
 
   //初期位置に配置するメソッド
@@ -110,6 +113,18 @@ export class Character extends GameObject {
       this.getPosition.x + this.getVelocity.x * deltaTime,
       this.getPosition.y + this.getVelocity.y * deltaTime
     );
+  }
+
+  // 障害物との干渉チェック
+  overlapBombs(bombList: GenericLinkedList<Bomb>) {
+    let iterator = bombList.getHead();
+    while (iterator !== null) {
+      if (OverlapUtil.overlapRects(this.rectBound, iterator.data.rectBound)) {
+        return iterator;
+      }
+      iterator = iterator.next;
+    }
+    return null;
   }
 
   //アニメーションを設定するメソッド

--- a/server/src/game/model/player/player.ts
+++ b/server/src/game/model/player/player.ts
@@ -4,6 +4,7 @@ import { ObjectUtil } from '../../util/object.util';
 import { OverlapUtil } from '../../util/overlap.util';
 import { Bomb } from '../bomb';
 import { Character } from '../character/character';
+import { Npc } from '../npc/npc';
 import { GenericObstacle } from '../obstacle/generic/genericObstacle';
 
 export class Player extends Character {
@@ -15,8 +16,8 @@ export class Player extends Character {
     left: false,
   };
 
-  private bombList = new GenericLinkedList<Bomb>();
-  private bombCountMax = 1;
+  public bombList = new GenericLinkedList<Bomb>();
+  private bombCountMax = 5;
   private score = 0;
 
   // コンストラクタ
@@ -34,7 +35,7 @@ export class Player extends Character {
     deltaTime: number,
     // obstacleSet: Set<GenericObstacle>
     obstacleList: GenericLinkedList<GenericObstacle>,
-    squareCache: Array<Array<GenericObstacle | null>>
+    squareCache: Array<Array<GenericObstacle | null>>,
   ) {
     // 移動前座標値のバックアップ
     const prevPosition = {
@@ -115,10 +116,14 @@ export class Player extends Character {
       }
     }
     if (collision) {
-      this.setPosition(prevPosition.x + correction.x, prevPosition.y + correction.y);
+      this.setPosition(
+        prevPosition.x + correction.x,
+        prevPosition.y + correction.y
+      );
       this.setVelocity(0, 0);
     }
   }
+  
   toJSON() {
     return Object.assign(super.toJSON(), {
       clientId: this.clientId,
@@ -131,14 +136,14 @@ export class Player extends Character {
   }
 
   // 爆弾を置く
-  putBomb() {
+  putBomb(id: number) {
     if (!this.canPutBomb()) {
       return null;
     }
 
-    const bomb = new Bomb(this.getPosition.x, this.getPosition.y, this, this.id);
+    const bomb = new Bomb(id, this.getPosition.x, this.getPosition.y, this);
     this.bombList.pushBack(bomb);
-    return bomb;
+    return new Bomb(id, this.getPosition.x, this.getPosition.y, this);
   }
 
   // 爆弾を置けるかどうか

--- a/server/src/socket/ioGame.ts
+++ b/server/src/socket/ioGame.ts
@@ -61,27 +61,10 @@ export default class IoGame {
       socket.on('putBomb', () => {
         if (!socket.roomId || !socket.clientId) return;
 
-        console.log('⚠ 爆弾設置！！！');
-
-        const playerList =
-          this.roomManager.roomMap[socket.roomId].gameManager.game.stage
-            .playerList;
-        let iterator = playerList.getHead();
-        while (iterator !== null) {
-          if (iterator.data.clientId === socket.clientId) {
-            if (iterator.data.getLife === 0) return;
-            else break;
-          }
-        }
-        if (!iterator?.data) return;
-
         // 爆弾を設置
-        //createBombメソッドを後で実装する
         this.roomManager.roomMap[
           socket.roomId
-        ].gameManager.game.stage.createBomb(
-          socket.clientId
-        );
+        ].gameManager.game.stage.createBomb(socket.clientId);
       });
 
       //接続が切れたとき


### PR DESCRIPTION
## PRの目的
- 爆弾を追加
- 当たり判定を追加

## 概要
- 爆弾を設置して、時間が経ったら削除する
- NPC対プレイヤー、NPC対爆弾の当たり判定を追加
## 内容
- スペースキーで爆弾を置けるようにしました。
- 設置して５秒後に消去するようにしました。
- プレイヤーは敵に３回ぶつかると消えるようにしました。
- 敵と爆弾に当たり判定を追加しました。

## 今後の課題
- プレイヤー対爆弾の当たり判定
- プレイヤーが敵に向かって進みながらぶつかると、残機がマイナス２されてしまう。
- プレイヤー残機が減った時に点滅させたいけど、方法が分からない。
- 爆風の実装
- アイテムの実装

