### PR TITLE
Feat/Collision of Player with Bomb

### DIFF
--- a/server/src/game/model/character/character.ts
+++ b/server/src/game/model/character/character.ts
@@ -19,6 +19,8 @@ export class Character extends GameObject {
 
   protected velocity = { x: 0, y: 0 };
 
+  private isJustPutBomb = false; //爆弾を置いたばかりかどうか。爆弾とプレイヤーの当たり判定で使用
+
   // 可動域
   protected rectField = ObjectUtil.calRectField(
     Character.WIDTH,
@@ -66,6 +68,13 @@ export class Character extends GameObject {
   }
   get getAnimation() {
     return this.animation;
+  }
+  get getIsJustPutBomb(): boolean {
+    return this.isJustPutBomb;
+  }
+
+  set setIsJustPutBomb(value: boolean) {
+    this.isJustPutBomb = value;
   }
 
   setVelocity(x: number, y: number) {
@@ -115,7 +124,7 @@ export class Character extends GameObject {
     );
   }
 
-  // 障害物との干渉チェック
+  // 爆弾との干渉チェック
   overlapBombs(bombList: GenericLinkedList<Bomb>) {
     let iterator = bombList.getHead();
     while (iterator !== null) {
@@ -124,6 +133,9 @@ export class Character extends GameObject {
       }
       iterator = iterator.next;
     }
+
+    //置いたばかりの爆弾とのoverlapがなくなったので、falseに設定する
+    this.setIsJustPutBomb = false;
     return null;
   }
 

--- a/server/src/game/model/player/player.ts
+++ b/server/src/game/model/player/player.ts
@@ -36,6 +36,7 @@ export class Player extends Character {
     // obstacleSet: Set<GenericObstacle>
     obstacleList: GenericLinkedList<GenericObstacle>,
     squareCache: Array<Array<GenericObstacle | null>>,
+    bombList: GenericLinkedList<Bomb>
   ) {
     // 移動前座標値のバックアップ
     const prevPosition = {
@@ -96,15 +97,25 @@ export class Player extends Character {
       x: 0,
       y: 0,
     };
+    // ステージの外に出た場合
     if (
       !OverlapUtil.pointInRect(this.rectField, {
         x: this.getPosition.x,
         y: this.getPosition.y,
       })
     ) {
-      // フィールドの外に出た。
       collision = true;
-    } else {
+    }
+    //爆弾と衝突した場合
+    if (this.overlapBombs(bombList)) {
+      //爆弾を置いたばかりかどうか
+      if (!this.getIsJustPutBomb) {
+        //爆弾と衝突
+        collision = true;
+      }
+    }
+    //障害物と衝突した場合
+    if (this.overlapObstacles(obstacleList)) {
       //衝突した障害物
       let obstacleNode = this.overlapObstacles(obstacleList);
       if (obstacleNode) {
@@ -115,6 +126,7 @@ export class Player extends Character {
         ObjectUtil.calCorrection(squareCache, obstacleNode, this, correction);
       }
     }
+    //衝突した場合は元の位置に戻す
     if (collision) {
       this.setPosition(
         prevPosition.x + correction.x,
@@ -123,7 +135,7 @@ export class Player extends Character {
       this.setVelocity(0, 0);
     }
   }
-  
+
   toJSON() {
     return Object.assign(super.toJSON(), {
       clientId: this.clientId,
@@ -140,6 +152,8 @@ export class Player extends Character {
     if (!this.canPutBomb()) {
       return null;
     }
+
+    this.setIsJustPutBomb = true;
 
     const bomb = new Bomb(id, this.getPosition.x, this.getPosition.y, this);
     this.bombList.pushBack(bomb);

--- a/server/src/game/stage/stage.ts
+++ b/server/src/game/stage/stage.ts
@@ -260,7 +260,12 @@ export class Stage {
     //プレイヤーごとの処理
     let playerIterator = this.playerList.getHead();
     while (playerIterator !== null) {
-      playerIterator.data.update(deltaTime, this.obstacleList, squareCache);
+      playerIterator.data.update(
+        deltaTime,
+        this.obstacleList,
+        squareCache,
+        this.bombList
+      );
       if (playerIterator.data.getLife <= 0) {
         console.log(
           `プレイヤー<${playerIterator.data.clientId}>の残機が０になりました。`


### PR DESCRIPTION
## PRの目的
- プレイヤーと爆弾の当たり判定を追加

## 内容
爆弾の設置は、プレイヤーがいる位置に設置されるので、
直前に置いた爆弾との当たり判定を無効にする必要がありました。
　→　Characterクラスに変数( isJustPutBomb: boolean ) を 追加してtrue / false を切り替えるようにしました。

