### PR TITLE
Feat/LifeGauge

### DIFF
--- a/client/pages/mypage/[id].tsx
+++ b/client/pages/mypage/[id].tsx
@@ -1,6 +1,6 @@
 import { Box, Button, Grid, Paper, styled, Typography } from '@mui/material';
 import { useRouter } from 'next/router';
-import React, { useEffect, useState, FC } from 'react';
+import React, { useEffect, useState, FC, ChangeEvent } from 'react';
 import { Layout } from '../../component/Layout';
 import Link from '../../src/Link';
 
@@ -15,15 +15,15 @@ const Item = styled(Paper)(({ theme }) => ({
 const Mypage = () => {
   const router = useRouter();
   const { id } = router.query;
-  const [UserName, setUserName] = useState('')
+  const [UserName, setUserName] = useState('');
 
   const handleChangeName = (e: ChangeEvent<HTMLInputElement>) => {
-    setUserName(e.target.value)
-  }
-  
+    setUserName(e.target.value);
+  };
+
   const handleClick = () => {
     // ログインAPIにPOSTする処理
-  }
+  };
   return (
     <Layout title='Mypage'>
       <Box
@@ -36,11 +36,13 @@ const Mypage = () => {
         }}
       >
         <Typography variant='h4' component='h1' gutterBottom>
-                      表示名
+          表示名
         </Typography>
         <input onChange={handleChangeName} value={UserName} />
         <div>
-        <Button color='success' variant='contained' onClick={handleClick}>決定</Button>
+          <Button color='success' variant='contained' onClick={handleClick}>
+            決定
+          </Button>
         </div>
       </Box>
       <Box

--- a/client/src/game/dto/character.dto.ts
+++ b/client/src/game/dto/character.dto.ts
@@ -1,8 +1,8 @@
 import { GameObjectDto } from './gameObject.dto';
 
 export interface CharacterDto extends GameObjectDto {
-  
   life: number;
+  initLife: number;
   direction: number;
   animation: string;
 }

--- a/client/src/game/types/objects.type.ts
+++ b/client/src/game/types/objects.type.ts
@@ -12,12 +12,16 @@ export type Objects = {
   playerMap: {
     [clientId: string]: {
       sprite: Phaser.GameObjects.Sprite;
+      leftGauge: Phaser.GameObjects.Graphics;
+      rightGauge: Phaser.GameObjects.Graphics;
       sync: PlayerDto | null;
     };
   };
   npcMap: {
     [id: string]: {
       sprite: Phaser.GameObjects.Sprite;
+      leftGauge: Phaser.GameObjects.Graphics;
+      rightGauge: Phaser.GameObjects.Graphics;
       sync: NpcDto | null;
     };
   };

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -921,9 +921,14 @@
   "resolved" "https://registry.npmjs.org/@next/font/-/font-13.1.1.tgz"
   "version" "13.1.1"
 
-"@next/swc-darwin-x64@13.1.1":
-  "integrity" "sha512-qWr9qEn5nrnlhB0rtjSdR00RRZEtxg4EGvicIipqZWEyayPxhUu6NwKiG8wZiYZCLfJ5KWr66PGSNeDMGlNaiA=="
-  "resolved" "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.1.1.tgz"
+"@next/swc-linux-x64-gnu@13.1.1":
+  "integrity" "sha512-nnjuBrbzvqaOJaV+XgT8/+lmXrSCOt1YYZn/irbDb2fR2QprL6Q7WJNgwsZNxiLSfLdv+2RJGGegBx9sLBEzGA=="
+  "resolved" "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.1.1.tgz"
+  "version" "13.1.1"
+
+"@next/swc-linux-x64-musl@13.1.1":
+  "integrity" "sha512-CM9xnAQNIZ8zf/igbIT/i3xWbQZYaF397H+JroF5VMOCUleElaMdQLL5riJml8wUfPoN3dtfn2s4peSr3azz/g=="
+  "resolved" "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.1.1.tgz"
   "version" "13.1.1"
 
 "@nodelib/fs.scandir@2.1.5":

--- a/server/src/game/model/character/character.ts
+++ b/server/src/game/model/character/character.ts
@@ -50,6 +50,7 @@ export class Character extends GameObject {
   toJSON() {
     return Object.assign(super.toJSON(), {
       life: this.life,
+      initLife: this.initLife,
       direction: this.direction,
       animation: this.animation,
     });
@@ -100,6 +101,9 @@ export class Character extends GameObject {
 
   set setLife(value: number) {
     this.life = value;
+  }
+  set setInitLife(value: number) {
+    this.initLife = value;
   }
 
   set setSpeed(value: number) {

--- a/server/src/game/model/npc/npc.ts
+++ b/server/src/game/model/npc/npc.ts
@@ -23,6 +23,7 @@ export class Npc extends Character {
 
     this.setSpeed = 30;
     this.setLife = 1;
+    this.setInitLife = 1
 
     //初めに進む向きと速度をランダムにセット
     this.setMoveRamdom();

--- a/server/src/game/model/player/player.ts
+++ b/server/src/game/model/player/player.ts
@@ -35,6 +35,8 @@ export class Player extends Character {
     stageHeight: number
   ) {
     super(Player.SPRITE_KEY, obstacleList, stageWidth, stageHeight);
+    this.setLife = 3;
+    this.setInitLife = 3;
   }
 
   // 更新

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -701,11 +701,6 @@
   "resolved" "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   "version" "1.0.0"
 
-"fsevents@~2.3.2":
-  "integrity" "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="
-  "resolved" "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz"
-  "version" "2.3.2"
-
 "function-bind@^1.1.1":
   "integrity" "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
   "resolved" "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz"


### PR DESCRIPTION
## PRの目的
- 残機メータを表示

## 概要
- SyncUtil.createLifeGaugeメソッドを実装

## 該当するコミット名
- プレイヤーと敵の残機を設定
- サーバーから送るデータに、残機の初期値を追加
- クライアント側のデータ型にラフゲージを追加
- クライアントが受け取るデータ型に、残機の初期値を追加
- プレイヤーと敵のライフゲージを設定

## 内容
Phaser.GameObjects.GraphicsのfillRectメソッドを使って、プレイヤーと敵に残機メーターを追加しました。

## 今後の課題
- 時間を表示
- プレイヤー名を表示
## Doc
https://1-notes.com/add-graphics/
## その他
