### PR TITLE
Fix/calCorrection

### DIFF
--- a/client/component/GameDisplay.tsx
+++ b/client/component/GameDisplay.tsx
@@ -3,9 +3,14 @@ import { useState } from 'react';
 import { useEffect } from 'react';
 import { Box } from '@mui/system';
 import { usePhaserConfig } from '../src/game/config/usePhaserConfig';
+import StateDisplay from './StateDisplay';
+import { useItemStore } from '../src/store/useItemStore';
+import { useTimeStore } from '../src/store/useTimeStore';
 
 const GameDisplay = () => {
   const [game, setGame] = useState<Phaser.Game>();
+
+  const updateTimeState = useTimeStore((state) => state.updateTimeState);
 
   //Phaserの設定
   const { config } = usePhaserConfig();
@@ -13,6 +18,8 @@ const GameDisplay = () => {
   //PhaserのGameを作成するメソッド
   const startPhaser = async () => {
     const phaserGame = new Phaser.Game(config);
+
+    phaserGame.events.on('updateTimeState', updateTimeState);
 
     setGame(phaserGame);
   };
@@ -28,11 +35,13 @@ const GameDisplay = () => {
         sx={{
           my: 4,
           display: 'flex',
-          flexDirection: 'row',
+          flexDirection: 'column',
           justifyContent: 'center',
           alignItems: 'center',
         }}
       >
+        <StateDisplay />
+
         <div id='phaser-game' className={styles.canvasBorder}></div>
       </Box>
     </>

--- a/client/component/StateDisplay.tsx
+++ b/client/component/StateDisplay.tsx
@@ -1,0 +1,136 @@
+import { Box } from '@mui/material';
+import Image from 'next/image';
+import React from 'react';
+import { useItemStore } from '../src/store/useItemStore';
+import { useSocketStore } from '../src/store/useSocketStore';
+import { useTimeStore } from '../src/store/useTimeStore';
+
+const StateDisplay = () => {
+  const { itemState } = useItemStore();
+  const updateItemState = useItemStore((state) => state.updateItemState);
+
+  const { timeState } = useTimeStore();
+  const resetTimeState = useTimeStore((state) => state.resetTimeState);
+
+  const { socketState } = useSocketStore();
+  const socket = socketState.socket;
+
+  socket?.on('disconnect', () => {
+    resetTimeState();
+  });
+
+  socket?.on(
+    'itemState',
+    (res: {
+      items: {
+        bombUp: number;
+        fireUp: number;
+        speedUp: number;
+      };
+    }) => {
+      updateItemState(res.items);
+    }
+  );
+
+  return (
+    <>
+      <Box
+        height={50}
+        sx={{
+          my: 1,
+          display: 'flex',
+          flexDirection: 'row',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
+        <Box
+          height={50}
+          width={150}
+          sx={{
+            my: 1,
+            display: 'flex',
+            flexDirection: 'row',
+            // justifyContent: 'center',
+            alignItems: 'center',
+          }}
+        >
+          <Box sx={{ typography: 'h6', fontWeight: 500 }}>
+            time: {Math.floor(timeState.time)}
+          </Box>
+        </Box>
+        <Box
+          height={50}
+          width={450}
+          sx={{
+            my: 1,
+            display: 'flex',
+            flexDirection: 'row',
+            justifyContent: 'space-around',
+            alignItems: 'center',
+          }}
+        >
+          <Box
+            sx={{
+              my: 1,
+              display: 'flex',
+              flexDirection: 'row',
+              // justifyContent: 'center',
+              alignItems: 'center',
+            }}
+          >
+            <Image
+              src='/assets/bean_blue.png'
+              alt=''
+              width={30}
+              height={30}
+            ></Image>{' '}
+            <Box sx={{ typography: 'h6', fontWeight: 500 }}>
+              {itemState.bombUp}
+            </Box>
+          </Box>
+          <Box
+            sx={{
+              my: 1,
+              display: 'flex',
+              flexDirection: 'row',
+              // justifyContent: 'center',
+              alignItems: 'center',
+            }}
+          >
+            <Image
+              src='/assets/bean_orange.png'
+              alt=''
+              width={30}
+              height={30}
+            ></Image>{' '}
+            <Box sx={{ typography: 'h6', fontWeight: 500 }}>
+              {itemState.fireUp}
+            </Box>
+          </Box>
+          <Box
+            sx={{
+              my: 1,
+              display: 'flex',
+              flexDirection: 'row',
+              // justifyContent: 'center',
+              alignItems: 'center',
+            }}
+          >
+            <Image
+              src='/assets/bean_yellow.png'
+              alt=''
+              width={30}
+              height={30}
+            ></Image>{' '}
+            <Box sx={{ typography: 'h6', fontWeight: 500 }}>
+              {itemState.speedUp}
+            </Box>
+          </Box>
+        </Box>
+      </Box>
+    </>
+  );
+};
+
+export default StateDisplay;

--- a/client/pages/index.tsx
+++ b/client/pages/index.tsx
@@ -16,7 +16,7 @@ export default function Home() {
   const [isAuth, setIsAuth] = React.useState(false);
   const [UserName, setUserName] = useState('')
 
-  const handleChangeName = (e: ChangeEvent<HTMLInputElement>) => {
+  const handleChangeName = (e: React.ChangeEvent<HTMLInputElement>) => {
     setUserName(e.target.value)
   }
   

--- a/client/pages/mypage/[id].tsx
+++ b/client/pages/mypage/[id].tsx
@@ -1,6 +1,6 @@
 import { Box, Button, Grid, Paper, styled, Typography } from '@mui/material';
 import { useRouter } from 'next/router';
-import React, { useEffect, useState, FC } from 'react';
+import React, { useEffect, useState, FC, ChangeEvent } from 'react';
 import { Layout } from '../../component/Layout';
 import Link from '../../src/Link';
 
@@ -15,15 +15,15 @@ const Item = styled(Paper)(({ theme }) => ({
 const Mypage = () => {
   const router = useRouter();
   const { id } = router.query;
-  const [UserName, setUserName] = useState('')
+  const [UserName, setUserName] = useState('');
 
   const handleChangeName = (e: ChangeEvent<HTMLInputElement>) => {
-    setUserName(e.target.value)
-  }
-  
+    setUserName(e.target.value);
+  };
+
   const handleClick = () => {
     // ログインAPIにPOSTする処理
-  }
+  };
   return (
     <Layout title='Mypage'>
       <Box
@@ -36,11 +36,13 @@ const Mypage = () => {
         }}
       >
         <Typography variant='h4' component='h1' gutterBottom>
-                      表示名
+          表示名
         </Typography>
         <input onChange={handleChangeName} value={UserName} />
         <div>
-        <Button color='success' variant='contained' onClick={handleClick}>決定</Button>
+          <Button color='success' variant='contained' onClick={handleClick}>
+            決定
+          </Button>
         </div>
       </Box>
       <Box

--- a/client/src/game/config/usePhaserConfig.tsx
+++ b/client/src/game/config/usePhaserConfig.tsx
@@ -11,7 +11,7 @@ export const usePhaserConfig = () => {
     type: Phaser.AUTO,
     scale: {
       parent: 'phaser-game',
-      width: 800,
+      width: 1056,
       height: 800,
     },
     physics: {

--- a/client/src/game/dto/character.dto.ts
+++ b/client/src/game/dto/character.dto.ts
@@ -1,8 +1,8 @@
 import { GameObjectDto } from './gameObject.dto';
 
 export interface CharacterDto extends GameObjectDto {
-  
   life: number;
+  initLife: number;
   direction: number;
   animation: string;
 }

--- a/client/src/game/scene/MainScene.ts
+++ b/client/src/game/scene/MainScene.ts
@@ -30,6 +30,7 @@ export class MainScene extends CustomScene {
     this.socket.on(
       'syncGame',
       (res: {
+        time: number;
         playerArr: PlayerDto[];
         npcArr: NpcDto[];
         obstacleArr: ObstacleDto[];
@@ -37,6 +38,8 @@ export class MainScene extends CustomScene {
         explosionArr: ExplosionDto[];
         itemArr: ItemDto[];
       }) => {
+        this.game.events.emit('updateTimeState', { time: res.time });
+
         SyncUtil.setPlayer(res.playerArr, this);
         SyncUtil.setNpc(res.npcArr, this);
         SyncUtil.setObstacle(res.obstacleArr, this);

--- a/client/src/game/types/objects.type.ts
+++ b/client/src/game/types/objects.type.ts
@@ -12,6 +12,7 @@ export type Objects = {
   playerMap: {
     [clientId: string]: {
       sprite: Phaser.GameObjects.Sprite;
+      nameText: Phaser.GameObjects.Text;
       leftGauge: Phaser.GameObjects.Graphics;
       rightGauge: Phaser.GameObjects.Graphics;
       sync: PlayerDto | null;

--- a/client/src/game/types/objects.type.ts
+++ b/client/src/game/types/objects.type.ts
@@ -12,12 +12,16 @@ export type Objects = {
   playerMap: {
     [clientId: string]: {
       sprite: Phaser.GameObjects.Sprite;
+      leftGauge: Phaser.GameObjects.Graphics;
+      rightGauge: Phaser.GameObjects.Graphics;
       sync: PlayerDto | null;
     };
   };
   npcMap: {
     [id: string]: {
       sprite: Phaser.GameObjects.Sprite;
+      leftGauge: Phaser.GameObjects.Graphics;
+      rightGauge: Phaser.GameObjects.Graphics;
       sync: NpcDto | null;
     };
   };

--- a/client/src/game/util/sync.util.ts
+++ b/client/src/game/util/sync.util.ts
@@ -57,7 +57,7 @@ export class SyncUtil {
 
     let color = 0x00ff00;
     if (character.life <= character.initLife / 3) {
-      color = 0x0000ff;
+      color = 0xff0000;
     }
     const leftGauge = scene.add
       .graphics()

--- a/client/src/game/util/sync.util.ts
+++ b/client/src/game/util/sync.util.ts
@@ -22,8 +22,11 @@ export class SyncUtil {
 
           const lifeGauge = SyncUtil.createLifeGauge(player, scene);
 
+          const nameText = SyncUtil.createNameText(player, scene);
+
           scene.objects.playerMap[player.clientId] = {
             sprite: sprite,
+            nameText: nameText,
             leftGauge: lifeGauge.leftGauge,
             rightGauge: lifeGauge.rightGauge,
             sync: null,
@@ -33,6 +36,17 @@ export class SyncUtil {
         scene.objects.playerMap[player.clientId]['sync'] = player;
       });
     }
+  }
+
+  static createNameText(player: PlayerDto, scene: CustomScene) {
+    return scene.add
+      .text(
+        player.x,
+        player.y - SyncUtil.CHARACTER_HEIGHT * 1.5,
+        player.userName
+      )
+      .setTint(0x333333)
+      .setOrigin(0.5);
   }
 
   //ライフゲージを作るメソッド
@@ -162,6 +176,7 @@ export class SyncUtil {
     let player = scene.objects.playerMap[clientId];
     if (!player) return;
     player.sprite.destroy();
+    player.nameText.destroy();
     player.leftGauge.destroy();
     player.rightGauge.destroy();
     player.sync = null;
@@ -276,8 +291,14 @@ export class SyncUtil {
         player.sprite.x = player.sync.x;
         player.sprite.y = player.sync.y;
 
+        player.nameText.destroy();
+
         player.leftGauge.destroy();
         player.rightGauge.destroy();
+
+        const nameText = SyncUtil.createNameText(player.sync, scene);
+
+        player.nameText = nameText;
 
         const lifeGauge = SyncUtil.createLifeGauge(player.sync, scene);
 

--- a/client/src/store/types/useItemStore.type.ts
+++ b/client/src/store/types/useItemStore.type.ts
@@ -1,0 +1,13 @@
+export type ItemState = {
+  fireUp: number;
+  bombUp: number;
+  speedUp: number;
+};
+
+//usePlayerStoreが持つ状態とメソッドの型
+export type ItemStore = {
+  itemState: ItemState;
+  resetItemState: () => void;
+
+  updateItemState: (payload: ItemState) => void;
+};

--- a/client/src/store/types/useSocketStore.type.ts
+++ b/client/src/store/types/useSocketStore.type.ts
@@ -4,7 +4,7 @@ export type SocketState = {
   socket: CustomSocket | null;
 };
 
-//useGameStoreが持つ状態とメソッドの型
+//useSocketStoreが持つ状態とメソッドの型
 export type SocketStore = {
   socketState: SocketState;
   resetSocketState: () => void;

--- a/client/src/store/types/useTimeStore.type.ts
+++ b/client/src/store/types/useTimeStore.type.ts
@@ -1,0 +1,11 @@
+export type TimeState = {
+  time: number;
+};
+
+//usePlayerStoreが持つ状態とメソッドの型
+export type TimeStore = {
+  timeState: TimeState;
+  resetTimeState: () => void;
+
+  updateTimeState: (payload: TimeState) => void;
+};

--- a/client/src/store/useItemStore.ts
+++ b/client/src/store/useItemStore.ts
@@ -1,0 +1,29 @@
+import create from 'zustand';
+import { ItemStore } from './types/useItemStore.type';
+
+export const useItemStore = create<ItemStore>((set) => ({
+  //初期値
+  itemState: {
+    fireUp: 0,
+    bombUp: 0,
+    speedUp: 0,
+  },
+
+  updateItemState: (payload) =>
+    set({
+      itemState: {
+        fireUp: payload.fireUp,
+        bombUp: payload.bombUp,
+        speedUp: payload.speedUp,
+      },
+    }),
+
+  resetItemState: () =>
+    set({
+      itemState: {
+        fireUp: 0,
+        bombUp: 0,
+        speedUp: 0,
+      },
+    }),
+}));

--- a/client/src/store/useTimeStore.ts
+++ b/client/src/store/useTimeStore.ts
@@ -1,0 +1,23 @@
+import create from 'zustand';
+import { TimeStore } from './types/useTimeStore.type';
+
+export const useTimeStore = create<TimeStore>((set) => ({
+  //初期値
+  timeState: {
+    time: 0,
+  },
+
+  updateTimeState: (payload) =>
+    set({
+      timeState: {
+        time: payload.time,
+      },
+    }),
+
+  resetTimeState: () =>
+    set({
+      timeState: {
+        time: 0,
+      },
+    }),
+}));

--- a/client/styles/GameDisplay.module.css
+++ b/client/styles/GameDisplay.module.css
@@ -1,13 +1,13 @@
 .canvasBorder {
-  border: 20px solid;
+  border: 10px solid;
   border-image: linear-gradient(
       to right bottom,
       #e0d9b6,
       #b4983a
     )
-    1 / 15px;
+    1 / 12px;
   outline: 3px outset #efe9cc;
-  padding: 20px;
+  padding: 12px;
   background: #fff;
   box-shadow: 1px 3px 10px #999;
 }

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -13,13 +12,9 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true
+    "incremental": true,
+    "lib": ["dom", "dom.iterable", "esnext"]
   },
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx",
-    "src/socket/interface"
-  ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"]
 }

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -921,9 +921,14 @@
   "resolved" "https://registry.npmjs.org/@next/font/-/font-13.1.1.tgz"
   "version" "13.1.1"
 
-"@next/swc-darwin-x64@13.1.1":
-  "integrity" "sha512-qWr9qEn5nrnlhB0rtjSdR00RRZEtxg4EGvicIipqZWEyayPxhUu6NwKiG8wZiYZCLfJ5KWr66PGSNeDMGlNaiA=="
-  "resolved" "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.1.1.tgz"
+"@next/swc-linux-x64-gnu@13.1.1":
+  "integrity" "sha512-nnjuBrbzvqaOJaV+XgT8/+lmXrSCOt1YYZn/irbDb2fR2QprL6Q7WJNgwsZNxiLSfLdv+2RJGGegBx9sLBEzGA=="
+  "resolved" "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.1.1.tgz"
+  "version" "13.1.1"
+
+"@next/swc-linux-x64-musl@13.1.1":
+  "integrity" "sha512-CM9xnAQNIZ8zf/igbIT/i3xWbQZYaF397H+JroF5VMOCUleElaMdQLL5riJml8wUfPoN3dtfn2s4peSr3azz/g=="
+  "resolved" "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.1.1.tgz"
   "version" "13.1.1"
 
 "@nodelib/fs.scandir@2.1.5":

--- a/server/src/game/game.ts
+++ b/server/src/game/game.ts
@@ -3,6 +3,7 @@ import { ServerConfig } from './config/serverConfig';
 import { FirstPaintStage } from './stage/paint/firstPaintStage';
 
 export class Game {
+  startTime: number = Date.now();
   time: number = Date.now();
   roomId: string;
   roomManager: RoomManager;
@@ -39,9 +40,11 @@ export class Game {
       // const nanoSecDiff =
       //   hrtimeDiff[0] * 1e9 + hrtimeDiff[1];
 
+      const time = (currTime - this.startTime) * 0.001;
+
       // //ルーム内のユーザーにデータを送信
       this.roomManager.ioNspGame.in(this.roomId).emit('syncGame', {
-        time: deltaTime,
+        time: time,
         playerArr: this.stage.playerList.toArray(),
         npcArr: this.stage.npcList.toArray(),
         bombArr: this.stage.bombList.toArray(),

--- a/server/src/game/model/character/character.ts
+++ b/server/src/game/model/character/character.ts
@@ -9,8 +9,8 @@ import { OverlapUtil } from '../../util/overlap.util';
 import { Explosion } from '../explosion';
 
 export class Character extends GameObject {
-  static WIDTH = 31.5;
-  static HEIGHT = 31.5;
+  static WIDTH = 29;
+  static HEIGHT = 29;
 
   protected direction = 2; // 0:up, 1:right, 2:down, 3:left
   protected speed = 50; // 速度[m/s]。1frameあたり5進む => 1/30[s] で5進む => 1[s]で150進む。

--- a/server/src/game/model/character/character.ts
+++ b/server/src/game/model/character/character.ts
@@ -50,6 +50,7 @@ export class Character extends GameObject {
   toJSON() {
     return Object.assign(super.toJSON(), {
       life: this.life,
+      initLife: this.initLife,
       direction: this.direction,
       animation: this.animation,
     });
@@ -100,6 +101,9 @@ export class Character extends GameObject {
 
   set setLife(value: number) {
     this.life = value;
+  }
+  set setInitLife(value: number) {
+    this.initLife = value;
   }
 
   set setSpeed(value: number) {

--- a/server/src/game/model/item/bombUpItem.ts
+++ b/server/src/game/model/item/bombUpItem.ts
@@ -13,6 +13,7 @@ export class BombUpItem extends GenericItem {
   public effect(player: Player): void {
     console.log('ボムアップ！');
     if (player.getBombCountMax >= 10) return;
+    player.items.bombUp++;
     player.setBombCountMax = player.getBombCountMax + 1;
   }
 }

--- a/server/src/game/model/item/fireUpItem.ts
+++ b/server/src/game/model/item/fireUpItem.ts
@@ -13,6 +13,7 @@ export class FireUpItem extends GenericItem {
   public effect(player: Player): void {
     console.log('ファイヤーアップ！');
     if (player.getBombStrength >= 10) return;
+    player.items.fireUp++;
     player.setBombStrength = player.getBombStrength + 1;
   }
 }

--- a/server/src/game/model/item/speedUpItem.ts
+++ b/server/src/game/model/item/speedUpItem.ts
@@ -13,6 +13,7 @@ export class SpeedUpItem extends GenericItem {
   public effect(player: Player): void {
     console.log('スピードアップ！');
     if (player.getSpeed >= 150) return;
+    player.items.speedUp++;
     player.setSpeed = player.getSpeed + 10;
   }
 }

--- a/server/src/game/model/npc/npc.ts
+++ b/server/src/game/model/npc/npc.ts
@@ -23,6 +23,7 @@ export class Npc extends Character {
 
     this.setSpeed = 30;
     this.setLife = 1;
+    this.setInitLife = 1
 
     //初めに進む向きと速度をランダムにセット
     this.setMoveRamdom();

--- a/server/src/game/model/npc/npc.ts
+++ b/server/src/game/model/npc/npc.ts
@@ -18,12 +18,12 @@ export class Npc extends Character {
     stageWidth: number,
     stageHeight: number
   ) {
-    super( Npc.SPRITE_KEY, obstacleList, stageWidth, stageHeight);
+    super(Npc.SPRITE_KEY, obstacleList, stageWidth, stageHeight);
     this.setSpriteKey = 'npc';
 
     this.setSpeed = 30;
     this.setLife = 1;
-    this.setInitLife = 1
+    this.setInitLife = 1;
 
     //初めに進む向きと速度をランダムにセット
     this.setMoveRamdom();
@@ -40,7 +40,7 @@ export class Npc extends Character {
     roomId: string
   ) {
     //ダメージを受けて3秒間は次のダメージを受けないように設定しているので、
-    //1.5秒を過ぎたら０に戻す
+    //3秒を過ぎたら０に戻す
     if (this.getNoDamageTime >= 3) {
       this.setNoDamageTime = 0;
     } else if (this.getNoDamageTime > 0) {
@@ -95,10 +95,15 @@ export class Npc extends Character {
     } else {
       let playerNode = this.overlapPlayers(playerList);
       if (playerNode) {
-        //プレイヤーの残機を減らす
-        playerNode.data.damage();
+        if (playerNode.data.getNoDamageTime <= 0) {
+          //プレイヤーの残機を減らす
+          playerNode.data.damage();
 
-        console.log(`残機: ${playerNode.data.getLife}`);
+          console.log(`残機: ${playerNode.data.getLife}`);
+
+          playerNode.data.setNoDamageTime = deltaTime;
+        }
+
         //プレイヤーに衝突
         collision = true;
         this.setPosition(prevPosition.x, prevPosition.y);

--- a/server/src/game/model/player/player.ts
+++ b/server/src/game/model/player/player.ts
@@ -1,5 +1,6 @@
 import { GenericLinkedList } from '../../../linkedList/generic/genericLinkedList';
 import RoomManager from '../../../manager/roomManager';
+import { CustomSocket } from '../../../socket/interface/customSocket.interface';
 import { Movement } from '../../types/movement.type';
 import { ObjectUtil } from '../../util/object.util';
 import { OverlapUtil } from '../../util/overlap.util';
@@ -19,6 +20,14 @@ export class Player extends Character {
     left: false,
   };
 
+  items = {
+    bombUp: 0,
+    fireUp: 0,
+    speedUp: 0,
+  };
+
+  public clientId = '';
+
   public bombList = new GenericLinkedList<Bomb>();
   private bombCountMax = 1;
   private score = 0;
@@ -28,13 +37,15 @@ export class Player extends Character {
   // コンストラクタ
   constructor(
     public id: number,
-    public clientId: string,
+    public socket: CustomSocket,
     public userName: string,
     obstacleList: GenericLinkedList<GenericObstacle>,
     stageWidth: number,
     stageHeight: number
   ) {
     super(Player.SPRITE_KEY, obstacleList, stageWidth, stageHeight);
+
+    this.clientId = socket.clientId!;
     this.setLife = 3;
     this.setInitLife = 3;
   }
@@ -174,9 +185,14 @@ export class Player extends Character {
       //アイテム効果発動
       item.data.effect(this);
       itemList.remove(item);
+      //クライアントからアイテムを削除
       roomManager.ioNspGame.in(roomId).emit('destroyItem', {
         id: item.data.id,
       });
+      //持っているアイテムの状態を送信
+      roomManager.ioNspGame
+        .to(this.socket.id)
+        .emit('itemState', { items: this.items });
     }
   }
 
@@ -194,9 +210,10 @@ export class Player extends Character {
 
   toJSON() {
     return Object.assign(super.toJSON(), {
-      clientId: this.clientId,
+      clientId: this.socket.clientId,
       userName: this.userName,
       score: this.score,
+      items: this.items,
     });
   }
 

--- a/server/src/game/model/player/player.ts
+++ b/server/src/game/model/player/player.ts
@@ -35,6 +35,8 @@ export class Player extends Character {
     stageHeight: number
   ) {
     super(Player.SPRITE_KEY, obstacleList, stageWidth, stageHeight);
+    this.setLife = 3;
+    this.setInitLife = 3;
   }
 
   // 更新

--- a/server/src/game/stage/generic/genericStage.ts
+++ b/server/src/game/stage/generic/genericStage.ts
@@ -11,6 +11,7 @@ import { MathUtil } from '../../util/math.util';
 import { Node } from '../../../linkedList/generic/node';
 import { GenericItem } from '../../model/item/genericItem';
 import { ItemFactory } from '../../factory/item/itemFactory';
+import { CustomSocket } from '../../../socket/interface/customSocket.interface';
 
 export class GenericStage {
   readonly STAGE_WIDTH = 800;
@@ -161,12 +162,12 @@ export class GenericStage {
   }
 
   //プレイヤーの作成
-  createPlayer(clientId: string, userName: string) {
+  createPlayer(socket: CustomSocket, userName: string) {
     const tail = this.playerList.getTail();
     const id = tail ? tail.data.id + 1 : 0;
     const player = new Player(
       id,
-      clientId,
+      socket,
       userName,
       this.obstacleList,
       this.STAGE_WIDTH,

--- a/server/src/game/stage/generic/genericStage.ts
+++ b/server/src/game/stage/generic/genericStage.ts
@@ -14,7 +14,7 @@ import { ItemFactory } from '../../factory/item/itemFactory';
 import { CustomSocket } from '../../../socket/interface/customSocket.interface';
 
 export class GenericStage {
-  readonly STAGE_WIDTH = 800;
+  readonly STAGE_WIDTH = 1056;
   readonly STAGE_HEIGHT = 800;
   readonly TILE_SIZE = 32;
   readonly TILE_SPAN_SCALE = 1.0;

--- a/server/src/game/util/object.util.ts
+++ b/server/src/game/util/object.util.ts
@@ -29,14 +29,18 @@ export class ObjectUtil {
   ) {
     //ぶつかった障害物
     const obstacle = obstacleNode.data;
+    console.log('obstacle: ', obstacle);
 
     const scale = 4 / 8;
     //補正を行うかどうかの判定で使用する(ずれが2/5であれば補正する)
     const requireX = ((obstacle.getWidth + player.getWidth) / 2) * scale;
     const requireY = ((obstacle.getHeight + player.getHeight) / 2) * scale;
     //マスのキャッシュ(squareCache)から、ぶつかった障害物をO(1)で探すためのインデックス
-    const iX = Math.floor(obstacle.id / squareCache.length);
-    const iY = obstacle.id % squareCache[iX].length;
+    const iX = Math.floor(obstacle.getPosition.x / obstacle.getWidth);
+    const iY = Math.floor(obstacle.getPosition.y / obstacle.getHeight);
+    // const iX = Math.floor(obstacle.id / squareCache.length);
+    // const iY = obstacle.id % squareCache[iX].length;
+
     //障害物とプレイヤーの座標の差
     let diffX = player.getPosition.x - obstacle.getPosition.x;
     let diffY = player.getPosition.y - obstacle.getPosition.y;
@@ -49,7 +53,10 @@ export class ObjectUtil {
         if (diffX <= diffY) {
           if (diffX >= requireX) {
             let nextObstacle = squareCache[iX + 1][iY];
-            if (!nextObstacle) {
+            console.log('ix: ', iX, ', iY : ', iY);
+            console.log('ix+1: ', iX + 1, ', iY : ', iY);
+            console.log('next', nextObstacle);
+            if (nextObstacle == null) {
               correction.x = (obstacle.getWidth + player.getWidth) / 2 - diffX;
             }
           }
@@ -57,7 +64,7 @@ export class ObjectUtil {
           if (diffY >= requireY) {
             //隣の障害物
             let nextObstacle = squareCache[iX][iY - 1];
-            if (!nextObstacle) {
+            if (nextObstacle == null) {
               correction.y =
                 -1 * (obstacle.getHeight / 2 + player.getHeight / 2 - diffY);
             }
@@ -69,7 +76,7 @@ export class ObjectUtil {
         if (diffX >= diffY) {
           if (diffY >= requireY) {
             let nextObstacle = squareCache[iX][iY + 1];
-            if (!nextObstacle) {
+            if (nextObstacle == null) {
               correction.y =
                 obstacle.getHeight / 2 + player.getHeight / 2 - diffY;
             }
@@ -77,7 +84,7 @@ export class ObjectUtil {
         } else {
           if (diffX >= requireX) {
             let nextObstacle = squareCache[iX + 1][iY];
-            if (!nextObstacle) {
+            if (nextObstacle == null) {
               correction.x = (obstacle.getWidth + player.getWidth) / 2 - diffX;
             }
           }
@@ -92,7 +99,7 @@ export class ObjectUtil {
         if (diffX <= diffY) {
           if (diffX >= requireX) {
             let nextObstacle = squareCache[iX - 1][iY];
-            if (!nextObstacle) {
+            if (nextObstacle == null) {
               correction.x =
                 -1 * ((obstacle.getWidth + player.getWidth) / 2 - diffX);
             }
@@ -100,7 +107,7 @@ export class ObjectUtil {
         } else {
           if (diffY >= requireY) {
             let nextObstacle = squareCache[iX][iY + 1];
-            if (!nextObstacle) {
+            if (nextObstacle == null) {
               correction.y =
                 obstacle.getHeight / 2 + player.getHeight / 2 - diffY;
             }
@@ -113,7 +120,7 @@ export class ObjectUtil {
         if (diffX >= diffY) {
           if (diffY >= requireY) {
             let nextObstacle = squareCache[iX][iY - 1];
-            if (!nextObstacle) {
+            if (nextObstacle == null) {
               correction.y =
                 -1 * (obstacle.getHeight / 2 + player.getHeight / 2 - diffY);
             }
@@ -121,7 +128,7 @@ export class ObjectUtil {
         } else {
           if (diffX >= requireX) {
             let nextObstacle = squareCache[iX - 1][iY];
-            if (!nextObstacle) {
+            if (nextObstacle == null) {
               correction.x =
                 -1 * ((obstacle.getWidth + player.getWidth) / 2 - diffX);
             }

--- a/server/src/manager/roomManager.ts
+++ b/server/src/manager/roomManager.ts
@@ -43,7 +43,7 @@ export default class RoomManager {
     let stage = this.roomMap[socket.roomId].gameManager.game.stage;
 
     // プレイヤーを作成
-    stage.createPlayer(socket.clientId, userName);
+    stage.createPlayer(socket, userName);
   }
 
   // socketを使ってユーザを入室させる

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -701,11 +701,6 @@
   "resolved" "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   "version" "1.0.0"
 
-"fsevents@~2.3.2":
-  "integrity" "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="
-  "resolved" "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz"
-  "version" "2.3.2"
-
 "function-bind@^1.1.1":
   "integrity" "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
   "resolved" "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz"


### PR DESCRIPTION
## PRの目的
- ステージを横長にしてサイズ変更すると、プレイヤー操作が上手くいかなくなるので修正

## 概要
- calCorrectionメソッドの修正

## 該当するコミット名
- calCorrectionメソッドを修正

## 内容
- ぶつかった障害物をキャッシュから探索する部分を修正しました。
(キャッシュのインデックスiXとiYを、障害物のidからではなく、障害物の座標から算出するようにしました。)

## 今後の課題
プレイヤーと敵の初期配置が被らないようにする
## Doc

## その他
