### PR TITLE
Fix/Destroy Player

### DIFF
--- a/client/src/game/scene/MainScene.ts
+++ b/client/src/game/scene/MainScene.ts
@@ -54,6 +54,7 @@ export class MainScene extends CustomScene {
     });
 
     this.socket.on('destroyPlayer', (res: { clientId: string }) => {
+      console.log(`プレイヤーsprite<clientId: ${res.clientId}>を削除します。`);
       SyncUtil.destroyPlayer(res.clientId, this);
     });
 

--- a/server/src/game/model/player/player.ts
+++ b/server/src/game/model/player/player.ts
@@ -178,15 +178,17 @@ export class Player extends Character {
         this.setNoDamageTime = deltaTime;
 
         //攻撃したプレイヤーのスコアを更新
-        explosion.data.player.attackPlayer();
-        roomManager.ioNspGame
-          .to(explosion.data.player.socket.id)
-          .emit('attack', {
-            score: {
-              attackPlayer: explosion.data.player.attackPlayerCount,
-              attackNpc: explosion.data.player.attackNpcCount,
-            },
-          });
+        if (explosion.data.player.id !== this.id) {
+          explosion.data.player.attackPlayer();
+          roomManager.ioNspGame
+            .to(explosion.data.player.socket.id)
+            .emit('attack', {
+              score: {
+                attackPlayer: explosion.data.player.attackPlayerCount,
+                attackNpc: explosion.data.player.attackNpcCount,
+              },
+            });
+        }
 
         //干渉した爆風を削除
         explosionList.remove(explosion);

--- a/server/src/game/stage/generic/genericStage.ts
+++ b/server/src/game/stage/generic/genericStage.ts
@@ -306,7 +306,7 @@ export class GenericStage {
     while (iterator !== null) {
       if (iterator.data.clientId === clientId) {
         //プレイヤーリストから削除
-        // this.playerList.remove(iterator);
+        this.playerList.remove(iterator);
 
         //削除したプレイヤーのクライアントに"dead"イベントを送信
         this.roomManager.ioNspGame.to(iterator.data.socket.id).emit('dead');
@@ -314,7 +314,7 @@ export class GenericStage {
         //clientIdのプレイヤーSpriteを破棄するようにクライアントに指示する
         this.roomManager.ioNspGame
           .in(this.roomId)
-          .emit('deadPlayer', { clientId: clientId });
+          .emit('destroyPlayer', { clientId: clientId });
 
         break;
       }


### PR DESCRIPTION
## PRの目的
- 接続が切れた、または残機が０になったプレイヤーのSprite描画を削除

## 概要
- socket.emit("destroyPlayer")を修正

## 該当するコミット名
- クライアントからプレイヤーを削除

## 内容
クライアントとサーバーでsocket通信のメッセージが一致していなかったので、
"destroyPlayer"に統一しました。

